### PR TITLE
[UNMERGEABLE] Add message visibility

### DIFF
--- a/src/Publisher/QueuePublisher.php
+++ b/src/Publisher/QueuePublisher.php
@@ -76,6 +76,26 @@ class QueuePublisher implements QueuePublisherInterface
     /**
      * {@inheritDoc}
      */
+    public function changeMessageVisibility(string $queue, string $receiptHandle, int $visibility)
+    {
+        if (!isset($this->queues[$queue])) {
+            throw new UnknownQueueException(sprintf(
+                'Queue "%s" is not mapped to an actual SQS queue URL. Did you make sure you have specified the
+                 queue into the "zfr_eb_worker" config?',
+                $queue
+            ));
+        }
+
+        $this->sqsClient->changeMessageVisibility([
+            'QueueUrl'          => $this->queues[$queue],
+            'ReceiptHandle'     => $receiptHandle,
+            'VisibilityTimeout' => $visibility
+        ]);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function flush()
     {
         // SQS does not support flushing in batch to different queues

--- a/src/Publisher/QueuePublisherInterface.php
+++ b/src/Publisher/QueuePublisherInterface.php
@@ -45,6 +45,16 @@ interface QueuePublisherInterface
     public function push(string $queue, string $jobName, array $attributes = [], array $options = []);
 
     /**
+     * Adjust the visibility of a given message
+     *
+     * @param  string $queue
+     * @param  string $receiptHandle
+     * @param  int    $visibility
+     * @return void
+     */
+    public function changeMessageVisibility(string $queue, string $receiptHandle, int $visibility);
+
+    /**
      * Flush the queue
      *
      * @return void


### PR DESCRIPTION
This cannot be merged for now because I didn't remember that for some obscure reason, the Beanstalk worker DOES NOT return the message visibility (as explained here: https://forums.aws.amazon.com/thread.jspa?threadID=221132&tstart=0).

So we need to wait that Amazon decide to add the receipt handle before merging that.
