### PR TITLE
Add config

### DIFF
--- a/config/routes.global.php
+++ b/config/routes.global.php
@@ -1,6 +1,6 @@
 <?php
 
-use ZfrEbWorker\WorkerMiddleware;
+use ZfrEbWorker\Middleware\WorkerMiddleware;
 
 return [
     'routes' => [

--- a/src/AppConfig.php
+++ b/src/AppConfig.php
@@ -1,0 +1,41 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license.
+ */
+
+namespace ZfrEbWorker;
+
+/**
+ * Provides a mergeable config
+ *
+ * This is mainly used for Zend-Expressive config, but could be used by any other library to merge this
+ * config as part of your application config
+ *
+ * @author Michaël Gallego
+ */
+class AppConfig
+{
+    /**
+     * @return array
+     */
+    public function __invoke(): array
+    {
+        return array_merge_recursive(
+            include_once 'config/dependencies.global.php',
+            include_once 'config/routes.global.php'
+        );
+    }
+}

--- a/test/AppConfigTest.php
+++ b/test/AppConfigTest.php
@@ -1,0 +1,33 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license.
+ */
+
+namespace ZfrEbWorkerTest;
+
+use ZfrEbWorker\AppConfig;
+
+class AppConfigTest extends \PHPUnit_Framework_TestCase
+{
+    public function testConfig()
+    {
+        $config = (new AppConfig())->__invoke();
+
+        $this->assertArrayHasKey('dependencies', $config);
+        $this->assertArrayHasKey('routes', $config);
+        $this->assertArrayHasKey('zfr_eb_worker', $config);
+    }
+}


### PR DESCRIPTION
ping @danizord

Actually the approach is not that bad and I misunderstood it a bit. The module (in this case this one) is NOT tied to Expressive, as it's actually only the consumer app that needs the dependency to the specific package.

And because the __invoke can be anything, we could quite easily achieve dependencies between modules by making sure the "AppConfig" also aggregates the config of its children.

I'm merging and tagging as 1.1.0 but feel free to tell me if you have any other idea.
