### PR TITLE
Add task name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.0.1
+
+* Add the attribute `worker.task_name` to the request attribute
+
 # 2.0.0
 
 * `jobs` were renamed `tasks` to be on-par with Elastic Beanstalk worker terminology.

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ class MyTaskMiddleware
         $queue       = $request->getAttribute('worker.matched_queue');
         $messageId   = $request->getAttribute('worker.message_id');
         $messageBody = $request->getAttribute('worker.message_body');
+        $taskName    = $request->getAttribute('worker.task_name');
     }
 }
 ```

--- a/src/Middleware/WorkerMiddleware.php
+++ b/src/Middleware/WorkerMiddleware.php
@@ -81,7 +81,8 @@ class WorkerMiddleware
         // so they can be easier to process, and set the message attributes
         $request = $request->withAttribute('worker.matched_queue', $request->getHeaderLine('X-Aws-Sqsd-Queue'))
             ->withAttribute('worker.message_id', $request->getHeaderLine('X-Aws-Sqsd-Msgid'))
-            ->withAttribute('worker.message_body', $message);
+            ->withAttribute('worker.message_body', $message)
+            ->withAttribute('worker.task_name', $taskName);
 
         return $middleware($request, $response, $out);
     }

--- a/test/Middleware/WorkerMiddlewareTest.php
+++ b/test/Middleware/WorkerMiddlewareTest.php
@@ -77,6 +77,7 @@ class WorkerMiddlewareTest extends \PHPUnit_Framework_TestCase
         $this->request->expects($this->at(3))->method('getHeaderLine')->with('X-Aws-Sqsd-Msgid')->willReturn('123abc');
         $this->request->expects($this->at(4))->method('withAttribute')->with('worker.message_id', '123abc')->willReturnSelf();
         $this->request->expects($this->at(5))->method('withAttribute')->with('worker.message_body', ['id' => 123])->willReturnSelf();
+        $this->request->expects($this->at(6))->method('withAttribute')->with('worker.task_name', 'task-name')->willReturnSelf();
 
         $middleware->__invoke($this->request, $this->response);
     }


### PR DESCRIPTION
Adds the matched task name as part of the request attribute. Useful if we need to re-insert the same task in a generic way.
