### PR TITLE
Add queue setter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.1.0
+
+* Add a new 
+
 # 2.0.4
 
 * Use `require_once` instead of `include_once` for `AppConfig`.

--- a/src/Publisher/QueuePublisher.php
+++ b/src/Publisher/QueuePublisher.php
@@ -54,6 +54,14 @@ class QueuePublisher implements QueuePublisherInterface
     /**
      * {@inheritDoc}
      */
+    public function setQueue(string $queue, string $queueUrl)
+    {
+        $this->queues[$queue] = $queueUrl;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function push(string $queue, string $taskName, array $attributes = [], array $options = [])
     {
         if (!isset($this->queues[$queue])) {
@@ -64,7 +72,9 @@ class QueuePublisher implements QueuePublisherInterface
             ));
         }
 
-        $this->messages[$queue][] = [
+        $queueUrl = $this->queues[$queue];
+
+        $this->messages[$queueUrl][] = [
             'options' => $options,
             'body'    => [
                 'task_name'  => $taskName,

--- a/src/Publisher/QueuePublisherInterface.php
+++ b/src/Publisher/QueuePublisherInterface.php
@@ -31,6 +31,15 @@ namespace ZfrEbWorker\Publisher;
 interface QueuePublisherInterface
 {
     /**
+     * Set a new queue using an URL
+     *
+     * @param  string $queue
+     * @param  string $queueUrl
+     * @return void
+     */
+    public function setQueue(string $queue, string $queueUrl);
+
+    /**
      * Push a message into the queue
      *
      * Supported options for now are:


### PR DESCRIPTION
This PR adds a new `setQueue` method that allows to add at runtime a new queue. This is needed when you cannot know when preparing the config what the queue is.

This also changes the inner logic, where $messages property is indexed by queue URL instead of queue name.
