### PR TITLE
Add SilentFailingListener to ignore messages silently

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ correct middleware.
 ### How to silently ignore some message?
 
 When ZfrEbWorker don't find a mapped middleware to handle a message, it throws a `RuntimeException`, which makes Elastic
-Beanstalk retry the message again later. However if you don't want to handle a specific message and don't Elastic
+Beanstalk retry the message again later. However if you don't want to handle a specific message and don't want Elastic
 Beanstalk to retry it later, you should map SilentFailingListener to the message, like that:
 
 ```php

--- a/README.md
+++ b/README.md
@@ -115,3 +115,16 @@ class MyEventMiddleware
 Elastic Beanstalk also supports periodic tasks through the usage of `cron.yaml` file. However, this is actually easier as you can
 specify a different URL on a task-basis. Therefore, you can dispatch to the URL of your choice and immediately be re-routed to the
 correct middleware.
+
+### How to silently ignore some message?
+
+When ZfrEbWorker don't find a mapped middleware to handle a message, it throws a `RuntimeException`, which makes Elastic
+Beanstalk retry the message again later. However if you don't want to handle a specific message and don't Elastic
+Beanstalk to retry it later, you should map SilentFailingListener to the message, like that:
+
+```php
+'zfr_eb_worker' => [
+    'messages' => [
+        'user.updated' => ZfrEbWorker\Listener\SilentFailingListener::class,
+    ]
+```

--- a/src/Listener/SilentFailingListener.php
+++ b/src/Listener/SilentFailingListener.php
@@ -17,8 +17,11 @@ final class SilentFailingListener
      *
      * @return ResponseInterface
      */
-    public function __invoke(ServerRequestInterface $request, ResponseInterface $response, callable $next): ResponseInterface
-    {
+    public function __invoke(
+        ServerRequestInterface $request,
+        ResponseInterface $response,
+        callable $next
+    ): ResponseInterface {
         return $response->withStatus(200);
     }
 }

--- a/src/Listener/SilentFailingListener.php
+++ b/src/Listener/SilentFailingListener.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace ZfrEbWorker\Listener;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * @author Daniel Gimenes
+ */
+final class SilentFailingListener
+{
+    /**
+     * @param ServerRequestInterface $request
+     * @param ResponseInterface      $response
+     * @param callable               $next
+     *
+     * @return ResponseInterface
+     */
+    public function __invoke(ServerRequestInterface $request, ResponseInterface $response, callable $next): ResponseInterface
+    {
+        return $response->withStatus(200);
+    }
+}

--- a/test/Listener/SilentFailingListenerTest.php
+++ b/test/Listener/SilentFailingListenerTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace ZfrEbWorkerTest\Listener;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use ZfrEbWorker\Listener\SilentFailingListener;
+
+/**
+ * @author Daniel Gimenes
+ */
+class SilentFailingListenerTest extends \PHPUnit_Framework_TestCase
+{
+    public function testReturnsSuccessResponse()
+    {
+        $request  = $this->prophesize(ServerRequestInterface::class);
+        $response = $this->prophesize(ResponseInterface::class);
+        $listener = new SilentFailingListener();
+
+        // Creates a response with status code 200
+        $successResponse = $this->prophesize(ResponseInterface::class)->reveal();
+
+        $response->withStatus(200)->shouldBeCalled()->willReturn($successResponse);
+
+        // It should not call $next
+        $next = function () {
+            $this->fail('$next should not be called!');
+        };
+
+        $returnedResponse = $listener($request->reveal(), $response->reveal(), $next);
+
+        $this->assertSame($successResponse, $returnedResponse);
+    }
+}


### PR DESCRIPTION
@bakura10 this is a listener that simply ignores the message and returns HTTP 200, preventing Beanstalk to retry the message later. It must be registered manually to specific messages that should not be handled. What do you think?
