### PR TITLE
Do not escape slashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.0.1
+
+* Slashes are not escaped anymore when JSON body is created.
+
 # 4.0.0
 
 * `QueuePublisherInterface` has been removed and replaced by a single `MessageQueueInterface`, tied to a single queue.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 4.0.1
 
-* Slashes are not escaped anymore when JSON body is created.
+* Message body is now encoded in RFC4627-compliant JSON by using some encoding flags.
 
 # 4.0.0
 

--- a/src/MessageQueue/MessageQueue.php
+++ b/src/MessageQueue/MessageQueue.php
@@ -28,6 +28,17 @@ use ZfrEbWorker\Message\MessageInterface;
 class MessageQueue implements MessageQueueInterface
 {
     /**
+     * Default flags for json_encode; value of:
+     *
+     * <code>
+     * JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT | JSON_UNESCAPED_SLASHES
+     * </code>
+     *
+     * @const int
+     */
+    const DEFAULT_JSON_FLAGS = 79;
+
+    /**
      * @var array[]
      */
     private $messages = [];
@@ -98,7 +109,7 @@ class MessageQueue implements MessageQueueInterface
             foreach ($messagesToPush as $key => $message) {
                 $messageParameters = [
                     'Id'           => $key, // Identifier of the message in the batch
-                    'MessageBody'  => json_encode($message['body'], JSON_UNESCAPED_SLASHES),
+                    'MessageBody'  => json_encode($message['body'], self::DEFAULT_JSON_FLAGS),
                     'DelaySeconds' => $message['options']['delay_seconds'] ?? null
                 ];
 

--- a/src/MessageQueue/MessageQueue.php
+++ b/src/MessageQueue/MessageQueue.php
@@ -98,7 +98,7 @@ class MessageQueue implements MessageQueueInterface
             foreach ($messagesToPush as $key => $message) {
                 $messageParameters = [
                     'Id'           => $key, // Identifier of the message in the batch
-                    'MessageBody'  => json_encode($message['body']),
+                    'MessageBody'  => json_encode($message['body'], JSON_UNESCAPED_SLASHES),
                     'DelaySeconds' => $message['options']['delay_seconds'] ?? null
                 ];
 

--- a/test/MessageQueue/MessageQueueTest.php
+++ b/test/MessageQueue/MessageQueueTest.php
@@ -57,13 +57,7 @@ class MessageQueueTest extends \PHPUnit_Framework_TestCase
                 [
                     'Id'           => 0,
                     'DelaySeconds' => 0,
-                    'MessageBody'  => json_encode([
-                        'name'    => 'message-name',
-                        'payload' => [
-                            'id'  => 123,
-                            'url' => 'https://www.test.com' // Make sure slashes are not escaped
-                        ]
-                    ], JSON_UNESCAPED_SLASHES),
+                    'MessageBody'  => '{"name":"message-name","payload":{"id":123,"url":"https://www.test.com"}}'
                 ]
             ]
         ];
@@ -87,12 +81,7 @@ class MessageQueueTest extends \PHPUnit_Framework_TestCase
                 [
                     'Id'           => 0,
                     'DelaySeconds' => 30,
-                    'MessageBody'  => json_encode([
-                        'name'    => 'message-name',
-                        'payload' => [
-                            'id' => 123
-                        ]
-                    ], JSON_UNESCAPED_SLASHES),
+                    'MessageBody'  => '{"name":"message-name","payload":{"id":123}}'
                 ]
             ]
         ];

--- a/test/MessageQueue/MessageQueueTest.php
+++ b/test/MessageQueue/MessageQueueTest.php
@@ -92,7 +92,7 @@ class MessageQueueTest extends \PHPUnit_Framework_TestCase
                         'payload' => [
                             'id' => 123
                         ]
-                    ]),
+                    ], JSON_UNESCAPED_SLASHES),
                 ]
             ]
         ];

--- a/test/MessageQueue/MessageQueueTest.php
+++ b/test/MessageQueue/MessageQueueTest.php
@@ -60,9 +60,10 @@ class MessageQueueTest extends \PHPUnit_Framework_TestCase
                     'MessageBody'  => json_encode([
                         'name'    => 'message-name',
                         'payload' => [
-                            'id' => 123
+                            'id'  => 123,
+                            'url' => 'https://www.test.com' // Make sure slashes are not escaped
                         ]
-                    ]),
+                    ], JSON_UNESCAPED_SLASHES),
                 ]
             ]
         ];
@@ -74,7 +75,7 @@ class MessageQueueTest extends \PHPUnit_Framework_TestCase
         }
 
         $queue = new MessageQueue('https://queue-url.aws.com', $this->sqsClient->reveal());
-        $queue->push(new Message('message-name', ['id' => 123]));
+        $queue->push(new Message('message-name', ['id' => 123, 'url' => 'https://www.test.com']));
         $queue->flush($async);
     }
 


### PR DESCRIPTION
Previously, slashes were escaped (which is the default behaviour of JSON encoder). This means that something like "https://www.example.com" was encoded as "https:\/\/www.example.com".

This was quite problematic when you need to output or send back url.

It now uses the UNESCAPED slashes option by default.
