### PR TITLE
Allow middlewares to return void

### DIFF
--- a/src/Middleware/Pipeline.php
+++ b/src/Middleware/Pipeline.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace ZfrEbWorker\Middleware;
+
+use Interop\Container\ContainerInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * @author Daniel Gimenes
+ */
+final class Pipeline
+{
+    /**
+     * @var ContainerInterface
+     */
+    private $container;
+
+    /**
+     * @var callable[]
+     */
+    private $middlewares = [];
+
+    /**
+     * @var null|callable
+     */
+    private $out;
+
+    /**
+     * @param ContainerInterface $container
+     * @param callable[]         $middlewares
+     * @param null|callable      $out
+     */
+    public function __construct(ContainerInterface $container, array $middlewares, callable $out = null)
+    {
+        $this->container   = $container;
+        $this->middlewares = $middlewares;
+        $this->out         = $out;
+    }
+
+    /**
+     * @param ServerRequestInterface $request
+     * @param ResponseInterface      $response
+     *
+     * @return ResponseInterface
+     */
+    public function __invoke(ServerRequestInterface $request, ResponseInterface $response): ResponseInterface
+    {
+        if (0 === count($this->middlewares)) {
+            $out = $this->out;
+
+            return null !== $out ? $out($request, $response) : $response;
+        }
+
+        /** @var callable $middleware */
+        $middleware = $this->container->get(array_shift($this->middlewares));
+        $result     = $middleware($request, $response, $this);
+
+        return $result instanceof ResponseInterface ? $result : $response;
+    }
+}

--- a/test/Middleware/PipelineTest.php
+++ b/test/Middleware/PipelineTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace ZfrEbWorkerTest\Middleware;
+
+use Interop\Container\ContainerInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Zend\Diactoros\Response;
+use Zend\Diactoros\ServerRequest;
+use ZfrEbWorker\Middleware\Pipeline;
+
+/**
+ * @author Daniel Gimenes
+ */
+final class PipelineTest extends \PHPUnit_Framework_TestCase
+{
+    public function testAllowsMiddlewareToReturnVoid()
+    {
+        $container = $this->prophesize(ContainerInterface::class);
+        $pipeline  = new Pipeline($container->reveal(), ['foo']);
+
+        $container->get('foo')->shouldBeCalled()->willReturn(
+            function (ServerRequestInterface $request, ResponseInterface $response) {
+                // void
+            }
+        );
+
+        $passedResponse   = new Response();
+        $returnedResponse = $pipeline(new ServerRequest(), $passedResponse);
+
+        self::assertSame($passedResponse, $returnedResponse);
+    }
+
+    public function testReturnsResponseIfNoOutProvided()
+    {
+        $container = $this->prophesize(ContainerInterface::class);
+        $pipeline  = new Pipeline($container->reveal(), ['foo']);
+
+        $responseFromMiddleware = new Response();
+
+        $container->get('foo')->shouldBeCalled()->willReturn(
+            function (ServerRequestInterface $request, ResponseInterface $response) use ($responseFromMiddleware) {
+                return $responseFromMiddleware;
+            }
+        );
+
+        $returnedResponse = $pipeline(new ServerRequest(), new Response());
+
+        self::assertSame($responseFromMiddleware, $returnedResponse);
+    }
+
+    public function testDelegatesToOut()
+    {
+        $container       = $this->prophesize(ContainerInterface::class);
+        $passedRequest   = new ServerRequest();
+        $passedResponse  = new Response();
+        $responseFromOut = new Response();
+        $out             = function (ServerRequestInterface $request, ResponseInterface $response) use (
+            $passedRequest,
+            $passedResponse,
+            $responseFromOut
+        ) {
+            self::assertSame($passedRequest, $request);
+            self::assertSame($passedResponse, $response);
+
+            return $responseFromOut;
+        };
+
+        $pipeline         = new Pipeline($container->reveal(), [], $out);
+        $returnedResponse = $pipeline($passedRequest, $passedResponse);
+
+        self::assertSame($responseFromOut, $returnedResponse);
+    }
+}


### PR DESCRIPTION
Most worker middlewares won't want to manipulate the response, so their signatures could be simplified to:

``` php
function (ServerRequestInterface $request) {
    // Do something and return void
}
```

Stratigility allows that behavior by automatically returning `$response` when middleware returns `void`, so I'm doing the same here to allow those simple signatures :)

I did not change `WorkerMiddleware` tests to make sure that it is backwards compatible, instead I've extracted the pipeline code to a `Pipeline` class to make it easier to test.
