### PR TITLE
Add X-HANDLED-BY header

### DIFF
--- a/src/Middleware/WorkerMiddleware.php
+++ b/src/Middleware/WorkerMiddleware.php
@@ -94,7 +94,10 @@ class WorkerMiddleware
             ->withAttribute(self::MESSAGE_PAYLOAD_ATTRIBUTE, $payload)
             ->withAttribute(self::MESSAGE_NAME_ATTRIBUTE, $name);
 
-        return $pipeline($request, $response);
+        /** @var ResponseInterface $response */
+        $response = $pipeline($request, $response);
+
+        return $response->withHeader('X-HANDLED-BY', 'ZfrEbWorker');
     }
 
     /**


### PR DESCRIPTION
Zend Expressive [returns 404 if `$response` object is not changed](https://github.com/zendframework/zend-expressive/blob/29a6578fe3cc7cc0180ce146425955cab529e0b5/src/TemplatedErrorHandler.php#L195-L217) at the end of pipeline, so I'm adding this header to make sure that we don't return a 404 if no listener touches the response.
