### PR TITLE
Add support for periodic tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 5.3.0
+
+* Add support for periodic tasks
+
 # 5.2.0
 
 * Always add a `X-Handled-By` to the response at the end of the worker pipeline. This allows to make sure that the original response is modified, as

--- a/README.md
+++ b/README.md
@@ -126,8 +126,8 @@ You can also attach multiple listeners to a given message, hence allowing to do 
 ### Configuring Elastic Beanstalk
 
 Then, you should configure your Elastic Beanstalk worker environment to push messages to "/internal/worker" URL (this is the
-default URL configured if you use Zend Expressive). You could even add a pre-routing middleware to do additional security check
-on this URL.
+default URL configured if you use Zend Expressive). By default, ZfrEbWorker do additional security checks to ensure that the request
+is coming from localhost (as the daemon is installed on EC2 instances directly and push the messages locally):
 
 ### Pushing message
 

--- a/config/routes.global.php
+++ b/config/routes.global.php
@@ -13,6 +13,6 @@ return [
                 WorkerMiddleware::class
             ],
             'allowed_methods' => ['POST'],
-        ],
+        ]
     ],
 ];

--- a/src/Middleware/WorkerMiddleware.php
+++ b/src/Middleware/WorkerMiddleware.php
@@ -79,8 +79,9 @@ class WorkerMiddleware
         ResponseInterface $response,
         callable $out = null
     ): ResponseInterface {
-        // Two types of messages can be dispatched: either a periodic task or a normal task. For periodic tasks, the worker daemon automatically adds
-        // the "X-Aws-Sqsd-Taskname" header. When we find it, we simply use this name as the message name and continue the process
+        // Two types of messages can be dispatched: either a periodic task or a normal task. For periodic tasks,
+        // the worker daemon automatically adds the "X-Aws-Sqsd-Taskname" header. When we find it, we simply use this
+        // name as the message name and continue the process
 
         if ($request->hasHeader('X-Aws-Sqsd-Taskname')) {
             return $this->processPeriodicTask($request, $response, $out);
@@ -95,8 +96,11 @@ class WorkerMiddleware
      * @param   callable|null         $out
      * @return ResponseInterface
      */
-    private function processTask(ServerRequestInterface $request, ResponseInterface $response, callable $out = null): ResponseInterface
-    {
+    private function processTask(
+        ServerRequestInterface $request,
+        ResponseInterface $response,
+        callable $out = null
+    ): ResponseInterface {
         // The full message is set as part of the body
         $body    = json_decode($request->getBody(), true);
         $name    = $body['name'];
@@ -124,8 +128,11 @@ class WorkerMiddleware
      * @param  callable|null          $out
      * @return ResponseInterface
      */
-    private function processPeriodicTask(ServerRequestInterface $request, ResponseInterface $response, callable $out = null): ResponseInterface
-    {
+    private function processPeriodicTask(
+        ServerRequestInterface $request,
+        ResponseInterface $response,
+        callable $out = null
+    ): ResponseInterface {
         // The full message is set as part of the body
         $name = $request->getHeaderLine('X-Aws-Sqsd-Taskname');
 


### PR DESCRIPTION
This PR adds support for Elastic Beanstalk periodic tasks, so that they are protected for localhost and work the exact same way as for standard task.