### PR TITLE
Move message name to SQS attributes

### DIFF
--- a/src/MessageQueue/MessageQueue.php
+++ b/src/MessageQueue/MessageQueue.php
@@ -106,9 +106,9 @@ class MessageQueue implements MessageQueueInterface
 
             foreach ($messagesToPush as $key => $message) {
                 $messageParameters = [
-                    'Id'           => $key, // Identifier of the message in the batch
+                    'Id'                => $key, // Identifier of the message in the batch
                     'MessageAttributes' => [
-                        'name' => [
+                        'Name' => [
                             'DataType'    => 'String',
                             'StringValue' => $message['name'],
                         ],

--- a/src/MessageQueue/MessageQueue.php
+++ b/src/MessageQueue/MessageQueue.php
@@ -69,13 +69,11 @@ class MessageQueue implements MessageQueueInterface
     public function push(MessageInterface $message)
     {
         $this->messages[] = [
+            'name'    => $message->getName(),
             'options' => [
-                'delay_seconds' => ($message instanceof DelayedMessage) ? $message->getDelay() : 0
+                'delay_seconds' => ($message instanceof DelayedMessage) ? $message->getDelay() : 0,
             ],
-            'body'    => [
-                'name'    => $message->getName(),
-                'payload' => $message->getPayload()
-            ]
+            'body' => $message->getPayload(),
         ];
     }
 
@@ -109,6 +107,12 @@ class MessageQueue implements MessageQueueInterface
             foreach ($messagesToPush as $key => $message) {
                 $messageParameters = [
                     'Id'           => $key, // Identifier of the message in the batch
+                    'MessageAttributes' => [
+                        'name' => [
+                            'DataType'    => 'String',
+                            'StringValue' => $message['name'],
+                        ],
+                    ],
                     'MessageBody'  => json_encode($message['body'], self::DEFAULT_JSON_FLAGS),
                     'DelaySeconds' => $message['options']['delay_seconds'] ?? null
                 ];

--- a/src/Middleware/WorkerMiddleware.php
+++ b/src/Middleware/WorkerMiddleware.php
@@ -89,7 +89,7 @@ class WorkerMiddleware
             $payload = [];
         } else {
             // The full message is set as part of the body
-            $name    = $request->getHeaderLine('X-Aws-Sqsd-Attr-name');
+            $name    = $request->getHeaderLine('X-Aws-Sqsd-Attr-Name');
             $payload = json_decode($request->getBody(), true);
         }
 

--- a/src/Middleware/WorkerMiddleware.php
+++ b/src/Middleware/WorkerMiddleware.php
@@ -89,9 +89,8 @@ class WorkerMiddleware
             $payload = [];
         } else {
             // The full message is set as part of the body
-            $body    = json_decode($request->getBody(), true);
-            $name    = $body['name'];
-            $payload = $body['payload'];
+            $name    = $request->getHeaderLine('X-Aws-Sqsd-Attr-name');
+            $payload = json_decode($request->getBody(), true);
         }
 
         // Let's create a middleware pipeline of mapped middlewares

--- a/test/MessageQueue/MessageQueueTest.php
+++ b/test/MessageQueue/MessageQueueTest.php
@@ -53,9 +53,9 @@ class MessageQueueTest extends \PHPUnit_Framework_TestCase
             'QueueUrl' => 'https://queue-url.aws.com',
             'Entries'  => [
                 [
-                    'Id' => 0,
+                    'Id'                => 0,
                     'MessageAttributes' => [
-                        'name' => [
+                        'Name' => [
                             'DataType'    => 'String',
                             'StringValue' => 'message-name',
                         ],
@@ -83,9 +83,9 @@ class MessageQueueTest extends \PHPUnit_Framework_TestCase
             'QueueUrl' => 'https://queue-url.aws.com',
             'Entries'  => [
                 [
-                    'Id' => 0,
+                    'Id'                => 0,
                     'MessageAttributes' => [
-                        'name' => [
+                        'Name' => [
                             'DataType'    => 'String',
                             'StringValue' => 'message-name',
                         ],

--- a/test/MessageQueue/MessageQueueTest.php
+++ b/test/MessageQueue/MessageQueueTest.php
@@ -20,11 +20,9 @@ namespace ZfrEbWorkerTest\MessageQueue;
 
 use Aws\Sqs\SqsClient;
 use Prophecy\Argument;
-use ZfrEbWorker\Exception\UnknownQueueException;
 use ZfrEbWorker\Message\DelayedMessage;
 use ZfrEbWorker\Message\Message;
 use ZfrEbWorker\MessageQueue\MessageQueue;
-use ZfrEbWorker\Publisher\QueuePublisher;
 
 class MessageQueueTest extends \PHPUnit_Framework_TestCase
 {
@@ -55,9 +53,15 @@ class MessageQueueTest extends \PHPUnit_Framework_TestCase
             'QueueUrl' => 'https://queue-url.aws.com',
             'Entries'  => [
                 [
-                    'Id'           => 0,
+                    'Id' => 0,
+                    'MessageAttributes' => [
+                        'name' => [
+                            'DataType'    => 'String',
+                            'StringValue' => 'message-name',
+                        ],
+                    ],
                     'DelaySeconds' => 0,
-                    'MessageBody'  => '{"name":"message-name","payload":{"id":123,"url":"https://www.test.com"}}'
+                    'MessageBody'  => '{"id":123,"url":"https://www.test.com"}'
                 ]
             ]
         ];
@@ -79,9 +83,15 @@ class MessageQueueTest extends \PHPUnit_Framework_TestCase
             'QueueUrl' => 'https://queue-url.aws.com',
             'Entries'  => [
                 [
-                    'Id'           => 0,
+                    'Id' => 0,
+                    'MessageAttributes' => [
+                        'name' => [
+                            'DataType'    => 'String',
+                            'StringValue' => 'message-name',
+                        ],
+                    ],
                     'DelaySeconds' => 30,
-                    'MessageBody'  => '{"name":"message-name","payload":{"id":123}}'
+                    'MessageBody'  => '{"id":123}'
                 ]
             ]
         ];

--- a/test/Middleware/WorkerMiddlewareTest.php
+++ b/test/Middleware/WorkerMiddlewareTest.php
@@ -148,7 +148,8 @@ class WorkerMiddlewareTest extends \PHPUnit_Framework_TestCase
         if ($isPeriodicTask) {
             $request = $request->withHeader('X-Aws-Sqsd-Taskname', 'message-name');
         } else {
-            $request->getBody()->write(json_encode(['name' => 'message-name', 'payload' => ['id' => 123]]));
+            $request = $request->withHeader('X-Aws-Sqsd-Attr-name', 'message-name');
+            $request->getBody()->write(json_encode(['id' => 123]));
         }
 
         return $request;

--- a/test/Middleware/WorkerMiddlewareTest.php
+++ b/test/Middleware/WorkerMiddlewareTest.php
@@ -148,7 +148,7 @@ class WorkerMiddlewareTest extends \PHPUnit_Framework_TestCase
         if ($isPeriodicTask) {
             $request = $request->withHeader('X-Aws-Sqsd-Taskname', 'message-name');
         } else {
-            $request = $request->withHeader('X-Aws-Sqsd-Attr-name', 'message-name');
+            $request = $request->withHeader('X-Aws-Sqsd-Attr-Name', 'message-name');
             $request->getBody()->write(json_encode(['id' => 123]));
         }
 


### PR DESCRIPTION
Closes #36 

I'm not sure if it works though, since [EB docs](http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/using-features-managing-env-tiers.html) only mention `X-Aws-Sqsd-Attr-message-attribute-name` header for Periodic Tasks.

I'll try to test it tomorrow with a real worker and SQS queue.