### PR TITLE
Optimize docker IP detection (again...)

### DIFF
--- a/src/Middleware/WorkerMiddleware.php
+++ b/src/Middleware/WorkerMiddleware.php
@@ -154,7 +154,7 @@ class WorkerMiddleware implements MiddlewareInterface
         $remoteAddr   = $serverParams['REMOTE_ADDR'] ?? 'unknown IP address';
 
         // If request is not originating from localhost or from Docker local IP, we throw an RuntimeException
-        if (!in_array($remoteAddr, self::LOCALHOST_ADDRESSES) && !fnmatch('172.1*.*', $remoteAddr)) {
+        if (!in_array($remoteAddr, self::LOCALHOST_ADDRESSES) && !fnmatch('172.*', $remoteAddr)) {
             throw new RuntimeException(sprintf(
                 'Worker requests must come from localhost, request originated from %s given',
                 $remoteAddr

--- a/test/Middleware/WorkerMiddlewareTest.php
+++ b/test/Middleware/WorkerMiddlewareTest.php
@@ -77,6 +77,8 @@ class WorkerMiddlewareTest extends \PHPUnit_Framework_TestCase
             ['127.0.0.1', true],
             ['::1', true],
             ['172.17.42.1', true],
+            ['172.20.42.1', true],
+            ['172.18.42.1', true],
             ['172.17.0.1', true],
             ['189.55.56.131', false]
         ];


### PR DESCRIPTION
Seems like docker is also using IPs like `172.20.x.x` (spotted on a colleague computer) so testing only `172.1*.*` seems not enough...