### PR TITLE
Add support for http-interop/http-middleware 0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 6.1.0
+
+Add support for http-interop/http-middleware 0.5
+
 # 6.0.3
 
 * Fix another issue with validating Docker IP :D.

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "aws/aws-sdk-php": "^3.0",
         "psr/container": "^1.0",
         "psr/http-message": "^1.0",
-        "http-interop/http-middleware": "^0.4.1"
+        "webimpress/http-middleware-compatibility": "^0.1.4"
     },
     "require-dev": {
         "phpunit/phpunit": "~5.1",

--- a/src/Listener/SilentFailingListener.php
+++ b/src/Listener/SilentFailingListener.php
@@ -2,9 +2,9 @@
 
 namespace ZfrEbWorker\Listener;
 
-use Interop\Http\ServerMiddleware\DelegateInterface;
-use Interop\Http\ServerMiddleware\MiddlewareInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
+use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface;
 use Zend\Diactoros\Response\EmptyResponse;
 
 /**

--- a/src/Middleware/WorkerMiddleware.php
+++ b/src/Middleware/WorkerMiddleware.php
@@ -18,11 +18,11 @@
 
 namespace ZfrEbWorker\Middleware;
 
-use Interop\Http\ServerMiddleware\DelegateInterface;
-use Interop\Http\ServerMiddleware\MiddlewareInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
+use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface;
 use ZfrEbWorker\Exception\InvalidArgumentException;
 use ZfrEbWorker\Exception\RuntimeException;
 

--- a/test/Listener/SilentFailingListenerTest.php
+++ b/test/Listener/SilentFailingListenerTest.php
@@ -2,8 +2,9 @@
 
 namespace ZfrEbWorkerTest\Listener;
 
-use Interop\Http\ServerMiddleware\DelegateInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
+use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface;
 use ZfrEbWorker\Listener\SilentFailingListener;
 
 /**

--- a/test/Listener/SilentFailingListenerTest.php
+++ b/test/Listener/SilentFailingListenerTest.php
@@ -4,7 +4,6 @@ namespace ZfrEbWorkerTest\Listener;
 
 use Psr\Http\Message\ServerRequestInterface;
 use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
-use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface;
 use ZfrEbWorker\Listener\SilentFailingListener;
 
 /**

--- a/test/Middleware/WorkerMiddlewareTest.php
+++ b/test/Middleware/WorkerMiddlewareTest.php
@@ -19,12 +19,12 @@
 namespace ZfrEbWorkerTest\Middleware;
 
 use DateTimeImmutable;
-use Interop\Http\ServerMiddleware\DelegateInterface;
-use Interop\Http\ServerMiddleware\MiddlewareInterface;
 use Prophecy\Argument;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
+use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface;
 use Zend\Diactoros\Response;
 use Zend\Diactoros\ServerRequest;
 use Zend\Diactoros\Stream;


### PR DESCRIPTION
The proposed PSR-15 interfaces changed again breaking BC, but @webimpress made this magic to support it without breaking BC :D