### PR TITLE
Separating the routing mechanism into a separate middleware

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,9 @@
         "aws/aws-sdk-php": "^3.0",
         "psr/container": "^1.0",
         "psr/http-message": "^1.0",
-        "webimpress/http-middleware-compatibility": "^0.1.4"
+        "webimpress/http-middleware-compatibility": "^0.1.4",
+        "zendframework/zend-stratigility": "^2.1",
+        "http-interop/http-middleware": "^0.5.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~5.1",

--- a/composer.json
+++ b/composer.json
@@ -28,8 +28,7 @@
         "psr/container": "^1.0",
         "psr/http-message": "^1.0",
         "webimpress/http-middleware-compatibility": "^0.1.4",
-        "zendframework/zend-stratigility": "^2.1",
-        "http-interop/http-middleware": "^0.5.0"
+        "zendframework/zend-stratigility": "^2.1"
     },
     "require-dev": {
         "phpunit/phpunit": "~5.1",

--- a/config/dependencies.global.php
+++ b/config/dependencies.global.php
@@ -8,11 +8,14 @@ use ZfrEbWorker\Container\InMemoryMessageQueueRepositoryFactory;
 use ZfrEbWorker\Container\WorkerCommandFactory;
 use ZfrEbWorker\Container\WorkerMiddlewareFactory;
 use ZfrEbWorker\Container\MessageRouterMiddlewareFactory;
+use ZfrEbWorker\Container\WorkerMessageAttributesMiddlewareFactory;
 use ZfrEbWorker\Listener\SilentFailingListener;
 use ZfrEbWorker\MessageQueue\InMemoryMessageQueueRepository;
 use ZfrEbWorker\MessageQueue\MessageQueueRepositoryInterface;
 use ZfrEbWorker\Middleware\WorkerMiddleware;
 use ZfrEbWorker\Middleware\MessageRouterMiddleware;
+use ZfrEbWorker\Middleware\WorkerMessageAttributesMiddleware;
+
 
 return [
     'dependencies' => [
@@ -21,12 +24,13 @@ return [
         ],
 
         'factories' => [
-            InMemoryMessageQueueRepository::class => InMemoryMessageQueueRepositoryFactory::class,
-            PublisherCommand::class               => PublisherCommandFactory::class,
-            SilentFailingListener::class          => InvokableFactory::class,
-            WorkerCommand::class                  => WorkerCommandFactory::class,
-            WorkerMiddleware::class               => WorkerMiddlewareFactory::class,
-            MessageRouterMiddleware::class        => MessageRouterMiddlewareFactory::class,
+            InMemoryMessageQueueRepository::class    => InMemoryMessageQueueRepositoryFactory::class,
+            PublisherCommand::class                  => PublisherCommandFactory::class,
+            SilentFailingListener::class             => InvokableFactory::class,
+            WorkerCommand::class                     => WorkerCommandFactory::class,
+            WorkerMiddleware::class                  => WorkerMiddlewareFactory::class,
+            MessageRouterMiddleware::class           => MessageRouterMiddlewareFactory::class,
+            WorkerMessageAttributesMiddleware::class => WorkerMessageAttributesMiddlewareFactory::class,
         ]
     ],
 ];

--- a/config/dependencies.global.php
+++ b/config/dependencies.global.php
@@ -7,10 +7,12 @@ use ZfrEbWorker\Container\PublisherCommandFactory;
 use ZfrEbWorker\Container\InMemoryMessageQueueRepositoryFactory;
 use ZfrEbWorker\Container\WorkerCommandFactory;
 use ZfrEbWorker\Container\WorkerMiddlewareFactory;
+use ZfrEbWorker\Container\MessageRouterMiddlewareFactory;
 use ZfrEbWorker\Listener\SilentFailingListener;
 use ZfrEbWorker\MessageQueue\InMemoryMessageQueueRepository;
 use ZfrEbWorker\MessageQueue\MessageQueueRepositoryInterface;
 use ZfrEbWorker\Middleware\WorkerMiddleware;
+use ZfrEbWorker\Middleware\MessageRouterMiddleware;
 
 return [
     'dependencies' => [
@@ -24,6 +26,7 @@ return [
             SilentFailingListener::class          => InvokableFactory::class,
             WorkerCommand::class                  => WorkerCommandFactory::class,
             WorkerMiddleware::class               => WorkerMiddlewareFactory::class,
+            MessageRouterMiddleware::class        => MessageRouterMiddlewareFactory::class,
         ]
     ],
 ];

--- a/src/Cli/WorkerCommand.php
+++ b/src/Cli/WorkerCommand.php
@@ -6,6 +6,7 @@ use Aws\Sqs\Exception\SqsException;
 use Aws\Sqs\SqsClient;
 use GuzzleHttp\Client as HttpClient;
 use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Exception\RequestException;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -174,7 +175,7 @@ class WorkerCommand extends Command
                     $response->getBody()
                 ));
             }
-        } catch (ClientException $e) {
+        } catch (ClientException | RequestException $e) {
             $output->writeln(sprintf(
                 '<error>Message "%s" could not be processed and back-end returned error %s. Reason: %s</error>',
                 $message['MessageId'],

--- a/src/Cli/WorkerCommand.php
+++ b/src/Cli/WorkerCommand.php
@@ -146,7 +146,7 @@ class WorkerCommand extends Command
             'X-Aws-Sqsd-First-Received-At' => $message['Attributes']['ApproximateFirstReceiveTimestamp'],
             'X-Aws-Sqsd-Receive-Count'     => $message['Attributes']['ApproximateReceiveCount'],
             'X-Aws-Sqsd-Sender-Id'         => $message['Attributes']['SenderId'],
-            'X-Aws-Sqsd-Attr-Name'         => (isset($message['MessageAttributes']['Name']['StringValue'])) ? $message['MessageAttributes']['Name']['StringValue'] : null;
+            'X-Aws-Sqsd-Attr-Name'         => (isset($message['MessageAttributes']['Name']['StringValue'])) ? $message['MessageAttributes']['Name']['StringValue'] : null,
         ];
 
         try {

--- a/src/Cli/WorkerCommand.php
+++ b/src/Cli/WorkerCommand.php
@@ -137,17 +137,21 @@ class WorkerCommand extends Command
         string $queueUrl,
         OutputInterface $output
     ) {
+        $headers = [
+            'User-Agent'                   => 'aws-sqsd/2.0',
+            'Content-Type'                 => 'application/json',
+            'X-Aws-Sqsd-Msgid'             => $message['MessageId'],
+            'X-Aws-Sqsd-Queue'             => $queueName,
+            'X-Aws-Sqsd-First-Received-At' => $message['Attributes']['ApproximateFirstReceiveTimestamp'],
+            'X-Aws-Sqsd-Receive-Count'     => $message['Attributes']['ApproximateReceiveCount'],
+            'X-Aws-Sqsd-Sender-Id'         => $message['Attributes']['SenderId'],
+        ];
+        if (isset($message['MessageAttributes']['Name']['StringValue'])) {
+            $headers['X-Aws-Sqsd-Attr-Name'] = $message['MessageAttributes']['Name']['StringValue'];
+        }
+
         $response = $this->httpClient->post($uri, [
-            'headers' => [
-                'User-Agent'                   => 'aws-sqsd/2.0',
-                'Content-Type'                 => 'application/json',
-                'X-Aws-Sqsd-Msgid'             => $message['MessageId'],
-                'X-Aws-Sqsd-Queue'             => $queueName,
-                'X-Aws-Sqsd-First-Received-At' => $message['Attributes']['ApproximateFirstReceiveTimestamp'],
-                'X-Aws-Sqsd-Receive-Count'     => $message['Attributes']['ApproximateReceiveCount'],
-                'X-Aws-Sqsd-Sender-Id'         => $message['Attributes']['SenderId'],
-                'X-Aws-Sqsd-Attr-Name'         => $message['MessageAttributes']['Name']['StringValue']
-            ],
+            'headers' => $headers,
             'json' => json_decode($message['Body'], true)
         ]);
 

--- a/src/Cli/WorkerCommand.php
+++ b/src/Cli/WorkerCommand.php
@@ -146,10 +146,8 @@ class WorkerCommand extends Command
             'X-Aws-Sqsd-First-Received-At' => $message['Attributes']['ApproximateFirstReceiveTimestamp'],
             'X-Aws-Sqsd-Receive-Count'     => $message['Attributes']['ApproximateReceiveCount'],
             'X-Aws-Sqsd-Sender-Id'         => $message['Attributes']['SenderId'],
+            'X-Aws-Sqsd-Attr-Name'         => (isset($message['MessageAttributes']['Name']['StringValue'])) ? $message['MessageAttributes']['Name']['StringValue'] : null;
         ];
-        if (isset($message['MessageAttributes']['Name']['StringValue'])) {
-            $headers['X-Aws-Sqsd-Attr-Name'] = $message['MessageAttributes']['Name']['StringValue'];
-        }
 
         try {
             $response = $this->httpClient->post($uri, [

--- a/src/Container/MessageRouterMiddlewareFactory.php
+++ b/src/Container/MessageRouterMiddlewareFactory.php
@@ -20,19 +20,25 @@ namespace ZfrEbWorker\Container;
 
 use Psr\Container\ContainerInterface;
 use ZfrEbWorker\Exception\RuntimeException;
-use ZfrEbWorker\Middleware\WorkerMiddleware;
+use ZfrEbWorker\Middleware\MessageRouterMiddleware;
 
 /**
- * @author Michaël Gallego
+ * @author Benoît Osterberger
  */
-class WorkerMiddlewareFactory
+class MessageRouterMiddlewareFactory
 {
     /**
      * @param  ContainerInterface $container
-     * @return WorkerMiddleware
+     * @return MessageRouterMiddleware
      */
-    public function __invoke(ContainerInterface $container): WorkerMiddleware
+    public function __invoke(ContainerInterface $container): MessageRouterMiddleware
     {
-        return new WorkerMiddleware();
+        $config = $container->get('config');
+
+        if (!isset($config['zfr_eb_worker'])) {
+            throw new RuntimeException('Key "zfr_eb_worker" is missing');
+        }
+
+        return new MessageRouterMiddleware($config['zfr_eb_worker']['messages'], $container);
     }
 }

--- a/src/Container/WorkerMessageAttributesMiddlewareFactory.php
+++ b/src/Container/WorkerMessageAttributesMiddlewareFactory.php
@@ -20,19 +20,19 @@ namespace ZfrEbWorker\Container;
 
 use Psr\Container\ContainerInterface;
 use ZfrEbWorker\Exception\RuntimeException;
-use ZfrEbWorker\Middleware\WorkerMiddleware;
+use ZfrEbWorker\Middleware\WorkerMessageAttributesMiddleware;
 
 /**
- * @author Michaël Gallego
+ * @author Benoît Osterberger
  */
-class WorkerMiddlewareFactory
+class WorkerMessageAttributesMiddlewareFactory
 {
     /**
      * @param  ContainerInterface $container
-     * @return WorkerMiddleware
+     * @return WorkerMessageAttributesMiddleware
      */
-    public function __invoke(ContainerInterface $container): WorkerMiddleware
+    public function __invoke(ContainerInterface $container): WorkerMessageAttributesMiddleware
     {
-        return new WorkerMiddleware($container);
+        return new WorkerMessageAttributesMiddleware();
     }
 }

--- a/src/Container/WorkerMiddlewareFactory.php
+++ b/src/Container/WorkerMiddlewareFactory.php
@@ -33,6 +33,12 @@ class WorkerMiddlewareFactory
      */
     public function __invoke(ContainerInterface $container): WorkerMiddleware
     {
-        return new WorkerMiddleware($container);
+        $config = $container->get('config');
+
+        if (!isset($config['zfr_eb_worker'])) {
+            throw new RuntimeException('Key "zfr_eb_worker" is missing');
+        }
+
+        return new WorkerMiddleware($config['zfr_eb_worker']['messages'], $container);
     }
 }

--- a/src/Middleware/MessageRouterMiddleware.php
+++ b/src/Middleware/MessageRouterMiddleware.php
@@ -1,0 +1,118 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license.
+ */
+
+namespace ZfrEbWorker\Middleware;
+
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
+use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface;
+use ZfrEbWorker\Exception\InvalidArgumentException;
+use ZfrEbWorker\Exception\RuntimeException;
+
+/**
+ * MessageRouter middleware
+ * What this thing does is Routing to a specific handler based on message name.
+ * You can find a complete reference of what Elastic Beanstalk set here:
+ * http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/using-features-managing-env-tiers.html
+ *
+ * @author Michaël Gallego
+ */
+class MessageRouterMiddleware implements MiddlewareInterface
+{
+    const MESSAGE_NAME_ATTRIBUTE = 'worker.message_name';
+
+    /**
+     * @var ContainerInterface
+     */
+    private $container;
+
+    /**
+     * Map message names to a middleware name. For instance:
+     * [
+     *     'image.saved' => ProcessImageMiddleware::class
+     * ]
+     *
+     * @var array
+     */
+    private $messagesMapping;
+
+    /**
+     * @param array              $messagesMapping
+     * @param ContainerInterface $container
+     */
+    public function __construct(array $messagesMapping, ContainerInterface $container)
+    {
+        $this->messagesMapping = $messagesMapping;
+        $this->container       = $container;
+    }
+
+    /**
+     * @param ServerRequestInterface $request
+     * @param DelegateInterface      $delegate
+     *
+     * @return ResponseInterface
+     */
+    public function process(ServerRequestInterface $request, DelegateInterface $delegate): ResponseInterface
+    {
+        $name = $request->getAttribute(WorkerMiddleware::MESSAGE_NAME_ATTRIBUTE);
+
+        // Let's create a middleware pipeline of mapped middlewares
+        $middleware = $this->getMiddlewareForMessage($name);
+        $response   = $middleware->process($request, $delegate);
+
+        // Some middleware may return a 204 or any other 2xx answer, which are considered as success. However Elastic Beanstalk is picky
+        // and only accept 200 OK to delete message. So we normalize any status in the 2xx range
+        $statusCode = $response->getStatusCode();
+
+        if ($statusCode >= 200 && $statusCode <= 299) {
+            $response = $response->withStatus(200);
+        }
+
+        return $response->withHeader('X-Handled-By', 'ZfrEbWorker');
+    }
+
+    /**
+     * @param string $messageName
+     *
+     * @return MiddlewareInterface
+     * @throws RuntimeException
+     * @throws InvalidArgumentException
+     */
+    private function getMiddlewareForMessage(string $messageName): MiddlewareInterface
+    {
+        if (!array_key_exists($messageName, $this->messagesMapping)) {
+            throw new RuntimeException(sprintf(
+                'No middleware was mapped for message "%s". Did you fill the "zfr_eb_worker" configuration?',
+                $messageName
+            ));
+        }
+
+        $mappedMiddleware = $this->messagesMapping[$messageName];
+
+        if (!is_string($mappedMiddleware)) {
+            throw new InvalidArgumentException(sprintf(
+                'Mapped middleware must be a string, %s given.',
+                is_object($mappedMiddleware) ? get_class($mappedMiddleware) : gettype($mappedMiddleware)
+            ));
+        }
+
+        return $this->container->get($mappedMiddleware);
+    }
+}

--- a/src/Middleware/WorkerMessageAttributesMiddleware.php
+++ b/src/Middleware/WorkerMessageAttributesMiddleware.php
@@ -1,0 +1,121 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license.
+ */
+
+namespace ZfrEbWorker\Middleware;
+
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
+use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface;
+use ZfrEbWorker\Exception\InvalidArgumentException;
+use ZfrEbWorker\Exception\RuntimeException;
+
+/**
+ * WorkerMessageAttributes middleware
+ * What this thing does is validating worker request and extracts message attributes
+ * You can find a complete reference of what Elastic Beanstalk set here:
+ * http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/using-features-managing-env-tiers.html
+ *
+ * @author Michaël Gallego
+ */
+class WorkerMessageAttributesMiddleware implements MiddlewareInterface
+{
+    const MESSAGE_ID_ATTRIBUTE           = 'worker.message_id';
+    const MESSAGE_NAME_ATTRIBUTE         = 'worker.message_name';
+    const MESSAGE_SCHEDULED_AT_ATTRIBUTE = 'worker.message_scheduled_at';
+    const MESSAGE_PAYLOAD_ATTRIBUTE      = 'worker.message_payload';
+    const MATCHED_QUEUE_ATTRIBUTE        = 'worker.matched_queue';
+    const LOCALHOST_ADDRESSES            = ['127.0.0.1', '::1'];
+
+    /**
+     * @param ServerRequestInterface $request
+     * @param DelegateInterface      $delegate
+     *
+     * @return ResponseInterface
+     */
+    public function process(ServerRequestInterface $request, DelegateInterface $delegate): ResponseInterface
+    {
+        $this->assertLocalhost($request);
+        $this->assertSqsUserAgent($request);
+
+        // Two types of messages can be dispatched: either a periodic task or a normal task. For periodic tasks,
+        // the worker daemon automatically adds the "X-Aws-Sqsd-Taskname" header. When we find it, we simply use this
+        // name as the message name and continue the process
+
+        if ($request->hasHeader('X-Aws-Sqsd-Taskname')) {
+            // The full message is set as part of the body
+            $name    = $request->getHeaderLine('X-Aws-Sqsd-Taskname');
+            $payload = [];
+        } else {
+            // The full message is set as part of the body
+            $name    = $request->getHeaderLine('X-Aws-Sqsd-Attr-Name');
+            $payload = json_decode($request->getBody(), true);
+        }
+
+        // Elastic Beanstalk set several headers. We will extract some of them and add them as part of the request
+        // attributes so they can be easier to process, and set the message attributes
+        $request = $request->withAttribute(self::MATCHED_QUEUE_ATTRIBUTE, $request->getHeaderLine('X-Aws-Sqsd-Queue'))
+            ->withAttribute(self::MESSAGE_ID_ATTRIBUTE, $request->getHeaderLine('X-Aws-Sqsd-Msgid'))
+            ->withAttribute(self::MESSAGE_SCHEDULED_AT_ATTRIBUTE, $request->getHeaderLine('X-Aws-Sqsd-Scheduled-At'))
+            ->withAttribute(self::MESSAGE_PAYLOAD_ATTRIBUTE, $payload)
+            ->withAttribute(self::MESSAGE_NAME_ATTRIBUTE, $name)
+            ->withParsedBody($payload);
+
+        $response = $delegate->process($request, $delegate);
+
+        // Some middleware may return a 204 or any other 2xx answer, which are considered as success. However Elastic Beanstalk is picky
+        // and only accept 200 OK to delete message. So we normalize any status in the 2xx range
+        $statusCode = $response->getStatusCode();
+
+        if ($statusCode >= 200 && $statusCode <= 299) {
+            $response = $response->withStatus(200);
+        }
+
+        return $response->withHeader('X-Handled-By', 'ZfrEbWorker');
+    }
+
+    /**
+     * @param ServerRequestInterface $request
+     */
+    private function assertLocalhost(ServerRequestInterface $request)
+    {
+        $serverParams = $request->getServerParams();
+        $remoteAddr   = $serverParams['REMOTE_ADDR'] ?? 'unknown IP address';
+
+        // If request is not originating from localhost or from Docker local IP, we throw an RuntimeException
+        if (!in_array($remoteAddr, self::LOCALHOST_ADDRESSES) && !fnmatch('172.*', $remoteAddr)) {
+            throw new RuntimeException(sprintf(
+                'Worker requests must come from localhost, request originated from %s given',
+                $remoteAddr
+            ));
+        }
+    }
+
+    /**
+     * @param ServerRequestInterface $request
+     */
+    private function assertSqsUserAgent(ServerRequestInterface $request)
+    {
+        $userAgent = $request->getHeaderLine('User-Agent');
+
+        if (false === stripos($userAgent, 'aws-sqsd')) {
+            throw new RuntimeException('Worker requests must come from "aws-sqsd" user agent');
+        }
+    }
+}

--- a/src/Middleware/WorkerMiddleware.php
+++ b/src/Middleware/WorkerMiddleware.php
@@ -27,7 +27,7 @@ use Zend\Stratigility\MiddlewarePipe;
 
 /**
  * Worker middleware
- * This class is kept for bck compatibility reasons only
+ * This class is kept for back compatibility reasons only
  * All it does is calling a new pipeline with WorkerMessageAttributesMiddleware and MessageRouterMiddleware
  *
  * @author Benoît Osterberger
@@ -47,7 +47,6 @@ class WorkerMiddleware implements MiddlewareInterface
     private $container;
 
     /**
-     * @param array              $messagesMapping
      * @param ContainerInterface $container
      */
     public function __construct(ContainerInterface $container)

--- a/src/Middleware/WorkerMiddleware.php
+++ b/src/Middleware/WorkerMiddleware.php
@@ -89,7 +89,8 @@ class WorkerMiddleware implements MiddlewareInterface
             $payload = [];
         } else {
             // The full message is set as part of the body
-            $name    = $request->getHeaderLine('X-Aws-Sqsd-Attr-Name');
+            // if no specific header is set use a default value, the event should be handled by subsequent middlewares
+            $name    = $request->hasHeader('X-Aws-Sqsd-Attr-Name') ? $request->getHeaderLine('X-Aws-Sqsd-Attr-Name') : 'default-message';
             $payload = json_decode($request->getBody(), true);
         }
 

--- a/src/Middleware/WorkerMiddleware.php
+++ b/src/Middleware/WorkerMiddleware.php
@@ -64,8 +64,7 @@ class WorkerMiddleware implements MiddlewareInterface
             $payload = [];
         } else {
             // The full message is set as part of the body
-            // if no specific header is set use a default value, the event should be handled by subsequent middlewares
-            $name    = $request->hasHeader('X-Aws-Sqsd-Attr-Name') ? $request->getHeaderLine('X-Aws-Sqsd-Attr-Name') : 'default-message';
+            $name    = $request->getHeaderLine('X-Aws-Sqsd-Attr-Name');
             $payload = json_decode($request->getBody(), true);
         }
 

--- a/src/Middleware/WorkerMiddleware.php
+++ b/src/Middleware/WorkerMiddleware.php
@@ -47,9 +47,10 @@ class WorkerMiddleware implements MiddlewareInterface
     private $container;
 
     /**
+     * @param array $messagesMapping        kept only for BC
      * @param ContainerInterface $container
      */
-    public function __construct(ContainerInterface $container)
+    public function __construct(array $messagesMapping, ContainerInterface $container)
     {
         $this->container = $container;
     }


### PR DESCRIPTION
Separating the routing mechanism into a separate middleware, so that you can pipe middlewares in between that handles these edge cases:

```
// Validates worker request and extracts message attributes
$pipeline->pipe(WorkerMiddleware::class); 

// Here you can optionally pipe additional middlewares in between, for instance:
$pipeline->pipe(IdentifyAwsInternalEventsMiddleware::class);

// Routes to a specific handler based on message name
$pipeline->pipe(MessageRouterMiddleware::class);
```